### PR TITLE
modificacion fav_icon

### DIFF
--- a/lib/providers/favorites_provider.dart
+++ b/lib/providers/favorites_provider.dart
@@ -24,17 +24,17 @@ class FavoritesProvider extends ChangeNotifier {
   // }
 
   setFavorite(Movie movie) {
-    if (_favorites.contains(movie)) {
-      _favorites.removeWhere((item) => item == jsonEncode(movie));
+    if (_favorites.contains(movie.id.toString())) {
+      _favorites.removeWhere((item) => item == movie.id.toString());
     } else {
-      _favorites.add(jsonEncode(movie));
+      _favorites.add(movie.id.toString());
     }
     notifyListeners();
   }
 
   Icon favIcon(Movie movie) {
     IconData icon;
-    if (_favorites.contains(jsonEncode(movie))) {
+    if (_favorites.contains(movie.id.toString())) {
       icon = Icons.favorite;
     } else {
       icon = Icons.favorite_border;

--- a/lib/providers/favorites_provider.dart
+++ b/lib/providers/favorites_provider.dart
@@ -7,9 +7,10 @@ import 'package:my_imdb/models/movie.dart';
 
 class FavoritesProvider extends ChangeNotifier {
   List<String> _favorites = [];
+  List<Movie> _favoriteMovies = [];
 
   List<Movie> get favorites {
-    List<Movie> list = _favorites.map((item) => jsonDecode(item));
+    List<Movie> list = _favoriteMovies.map((item) => item).toList();
     return list;
   }
 
@@ -26,9 +27,14 @@ class FavoritesProvider extends ChangeNotifier {
   setFavorite(Movie movie) {
     if (_favorites.contains(movie.id.toString())) {
       _favorites.removeWhere((item) => item == movie.id.toString());
+      _favoriteMovies
+          .removeWhere((item) => item.id.toString() == movie.id.toString());
     } else {
       _favorites.add(movie.id.toString());
+      _favoriteMovies.add(movie);
     }
+
+    print(_favoriteMovies);
     notifyListeners();
   }
 


### PR DESCRIPTION
En el favorites_provider.dart modifique que en vez que la lista tenga movies, solo tenga el id de la movie que pusiste en favoritos.
Tocas el corazon, se graba el id de la pelicula que tocaste. Volves a tocar, el id desaparece de la lista. 
Creo que el jsonEncode lo que hace es pasar al objeto a String, en mi experiencia comparar objetos convertidos a Strings no tiro buenos resultados. Por eso opte por mandar el id.

Luego cree otra lista donde mando la movie. Si toco el corazon agrega el id a una lista y la movie a otra lista. Si lo desmarco, hace el proceso de borrado en las 2 listas.

Ademas en el get de los favoritos lo que hice fue que devuelva la lista de movies y le agregue un .toList() que vi en una pregunta de stackoverflow.

